### PR TITLE
implementation of foldLabels

### DIFF
--- a/Data/OpenRecords.hs
+++ b/Data/OpenRecords.hs
@@ -35,6 +35,7 @@ module Data.OpenRecords
              rename, renameUnique, Rename,
              -- ** Restriction
              (.-), (:-), 
+             Restrict(..),
              -- ** Update
              update,
              -- * Query
@@ -214,6 +215,18 @@ type family (l :: Row *) :++  (r :: Row *)  :: Row * where
 -- | Type level operation of '.+'
 type family (l :: Row *) :+  (r :: Row *)  :: Row * where
   (R l) :+ (R r) = R (Merge l r)
+
+class Restrict (ls :: [Symbol]) where
+  type Restricted ls (r :: Row *) :: Row *
+  restrict :: Rec r -> Rec (Restricted ls r)
+
+instance Restrict '[] where
+  type Restricted '[] r = Empty
+  restrict _ = empty
+
+instance (KnownSymbol l, Restrict ls) => Restrict (l ': ls) where
+  type Restricted (l ': ls) r = Extend l (r :! l) (Restricted ls r)
+  restrict r = extend (Label @l) (r .! Label @l) (restrict @ls r)
 
 {--------------------------------------------------------------------
   Syntactic sugar for record operations

--- a/Data/OpenRecords.hs
+++ b/Data/OpenRecords.hs
@@ -49,6 +49,7 @@ module Data.OpenRecords
              -- * Row constraints
              (:\), Disjoint, Labels, Forall(..),
              -- * Row only operations
+             RowMap (..), RowMapC (..),
              -- * Syntactic sugar
              RecOp(..), RowOp(..), (.|), (:|)
 

--- a/Data/OpenRecords.hs
+++ b/Data/OpenRecords.hs
@@ -218,9 +218,8 @@ type family (l :: Row *) :+  (r :: Row *)  :: Row * where
 {--------------------------------------------------------------------
   Syntactic sugar for record operations
 --------------------------------------------------------------------}
--- | A constraint not constraining anything
-class NoConstr a 
-instance NoConstr a
+class Yes1 a
+instance Yes1 a
 
 -- | Alias for ':\'. It is a class rather than an alias, so that
 --   it can be partially appliced.
@@ -266,9 +265,9 @@ infix 5 :<-
 --  [@:<-!@] Record label renaming. Sugar for 'renameUnique'.
 data RecOp (c :: Row * -> Constraint) (rowOp :: RowOp *) where
   (:<-)  :: KnownSymbol l           => Label l -> a      -> RecOp (HasType l a) RUp
-  (:=)   :: KnownSymbol l           => Label l -> a      -> RecOp NoConstr (l ::= a)  
+  (:=)   :: KnownSymbol l           => Label l -> a      -> RecOp Yes1 (l ::= a)  
   (:!=)  :: KnownSymbol l => Label l -> a      -> RecOp (Lacks l) (l ::= a)  
-  (:<-|) :: (KnownSymbol l, KnownSymbol l') => Label l' -> Label l -> RecOp NoConstr (l' ::<-| l)
+  (:<-|) :: (KnownSymbol l, KnownSymbol l') => Label l' -> Label l -> RecOp Yes1 (l' ::<-| l)
   (:<-!) :: (KnownSymbol l, KnownSymbol l', r :\ l') => Label l' -> Label l -> RecOp (Lacks l') (l' ::<-| l)
 
 
@@ -357,9 +356,6 @@ class Forall (r :: Row *) (c :: * -> Constraint) where
   -- apply the function to each pair of values that can be obtained by indexing the two records
   -- with the same label and collect the result in a list.
   eraseZip :: Proxy c -> (forall a. c a => a -> a -> b) -> Rec r -> Rec r -> [b]
-
-class Yes1 a
-instance Yes1 a
 
 labels :: IsString s => Forall r Yes1 => Rec r -> [s]
 labels = fmap fst . eraseWithLabels (Proxy @Yes1) (pure ())


### PR DESCRIPTION
- Allow you to get the fields of a record *type* without
  having a value of the record. It unifies several operations
  in the current `Forall` class.

- Ideally we could replace `Forall` with this new class.